### PR TITLE
Correct for different line separators

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -42,6 +42,7 @@ void LoadDictionary(const char* fname, int length, Trie& trie, int min_freq) {
   std::ifstream fin(fname);
   std::string line;
   while (std::getline(fin, line)) {
+    if (line[line.size() - 1] == '\r') line = line.substr(0, line.size() - 1);
     if (line.size() != length) { continue; }
     for (auto& c : line) c = toupper(c);
     if (g_freqs.size() > 0 && min_freq > 0) {


### PR DESCRIPTION
Since UNIX-Systems only use `LF` for a line-break and Windows uses `CRLF`, `std::getline` handles the separator differently depending on the platform. This causes problems with wordlists formatted in Windows-style line-breaks when using them on UNIX-like systems.

This quick fix just removes the trailing `CR` left in `line` by `std::getline` if it exists.